### PR TITLE
Add basic LuCI UI for wfb-ng

### DIFF
--- a/openwrt/README.md
+++ b/openwrt/README.md
@@ -5,3 +5,4 @@
 1. Create a [custom feed](https://openwrt.org/docs/guide-developer/toolchain/use-buildsystem#creating_a_local_feed) using full path to this directory
 2. Configure OpenWrt via `make menuconfig` - select `wfb-ng` or `wfb-ng-full` package according to your needs
 3. Build OpenWrt via `make`
+4. Optionally select `luci-app-wfb-ng` to configure and monitor the link via the LuCI web interface. The LuCI pages provide a form-based editor for `/etc/wifibroadcast.cfg` and a live RSSI graph.

--- a/openwrt/net/luci-app-wfb-ng/Makefile
+++ b/openwrt/net/luci-app-wfb-ng/Makefile
@@ -1,0 +1,10 @@
+include $(TOPDIR)/rules.mk
+
+LUCI_TITLE:=LuCI support for WFB-ng
+LUCI_DEPENDS:=+wfb-ng-full +luci-base +luci-lib-nixio
+LUCI_PKGARCH:=all
+PKG_MAINTAINER:=wfb-ng developers
+
+include $(TOPDIR)/feeds/luci/luci.mk
+
+$(call BuildPackage,luci-app-wfb-ng)

--- a/openwrt/net/luci-app-wfb-ng/luasrc/controller/wfbng.lua
+++ b/openwrt/net/luci-app-wfb-ng/luasrc/controller/wfbng.lua
@@ -1,0 +1,34 @@
+module("luci.controller.wfbng", package.seeall)
+
+function index()
+    if not nixio.fs.access("/etc/wifibroadcast.cfg") then
+        return
+    end
+
+    local page = entry({"admin", "services", "wfb-ng"}, firstchild(), _("WFB-ng"), 90)
+    page.dependent = false
+
+    entry({"admin", "services", "wfb-ng", "config"}, cbi("wfbng"), _("Configuration"), 1)
+    entry({"admin", "services", "wfb-ng", "status"}, template("wfbng/status"), _("Status"), 2)
+    entry({"admin", "services", "wfb-ng", "stats"}, call("action_stats")).leaf = true
+end
+
+function action_stats()
+    local http = require "luci.http"
+    local nixio = require "nixio"
+
+    local sock = nixio.socket("inet", "stream")
+    if not sock or not sock:connect("127.0.0.1", 8103) then
+        http.status(500, "connect failed")
+        return
+    end
+    local line = sock:recvline()
+    sock:close()
+
+    if not line then
+        http.status(204, "no content")
+        return
+    end
+    http.prepare_content("application/json")
+    http.write(line)
+end

--- a/openwrt/net/luci-app-wfb-ng/luasrc/model/cbi/wfbng.lua
+++ b/openwrt/net/luci-app-wfb-ng/luasrc/model/cbi/wfbng.lua
@@ -1,0 +1,73 @@
+local fs = require "nixio.fs"
+
+local cfgfile = "/etc/wifibroadcast.cfg"
+
+local function trim(s)
+    return (s:gsub("^%s+", ""):gsub("%s+$", ""))
+end
+
+local function read_config(path)
+    local res = {}
+    local section
+    local fd = io.open(path)
+    if not fd then return res end
+    for line in fd:lines() do
+        line = trim(line)
+        if line:sub(1,1) ~= "#" and line ~= "" then
+            local sec = line:match("^%[(.+)%]$")
+            if sec then
+                section = sec
+                res[section] = res[section] or {}
+            elseif section then
+                local k, v = line:match("([^=]+)=(.+)")
+                if k and v then
+                    res[section][trim(k)] = trim(v)
+                end
+            end
+        end
+    end
+    fd:close()
+    return res
+end
+
+local function write_config(path, cfg)
+    local lines = {}
+    for s, opts in pairs(cfg) do
+        lines[#lines+1] = "["..s.."]"
+        for k,v in pairs(opts) do
+            lines[#lines+1] = k .. " = " .. v
+        end
+        lines[#lines+1] = ""
+    end
+    fs.writefile(path, table.concat(lines, "\n"))
+end
+
+m = SimpleForm("wfbng", "WFB-ng Configuration")
+m.reset = false
+m.cfg = read_config(cfgfile)
+
+local wifi_channel = m:field(Value, "wifi_channel", "WiFi Channel")
+wifi_channel.default = m.cfg.common and m.cfg.common.wifi_channel or ""
+
+local wifi_region = m:field(Value, "wifi_region", "WiFi Region")
+wifi_region.default = m.cfg.common and m.cfg.common.wifi_region or ""
+
+local gs_mavlink_peer = m:field(Value, "gs_mavlink_peer", "GS Mavlink Peer")
+gs_mavlink_peer.default = m.cfg.gs_mavlink and m.cfg.gs_mavlink.peer or ""
+
+local gs_video_peer = m:field(Value, "gs_video_peer", "GS Video Peer")
+gs_video_peer.default = m.cfg.gs_video and m.cfg.gs_video.peer or ""
+
+function m.on_commit(self)
+    local cfg = read_config(cfgfile)
+    cfg.common = cfg.common or {}
+    cfg.common.wifi_channel = wifi_channel:formvalue("")
+    cfg.common.wifi_region = wifi_region:formvalue("")
+    cfg.gs_mavlink = cfg.gs_mavlink or {}
+    cfg.gs_mavlink.peer = gs_mavlink_peer:formvalue("")
+    cfg.gs_video = cfg.gs_video or {}
+    cfg.gs_video.peer = gs_video_peer:formvalue("")
+    write_config(cfgfile, cfg)
+end
+
+return m

--- a/openwrt/net/luci-app-wfb-ng/luasrc/view/wfbng/status.htm
+++ b/openwrt/net/luci-app-wfb-ng/luasrc/view/wfbng/status.htm
@@ -1,0 +1,44 @@
+<%+header%>
+<h2><%:WFB-ng Statistics%></h2>
+<canvas id="rssiChart" width="600" height="200" style="border:1px solid #ccc;"></canvas>
+<script type="text/javascript">
+    var rssiData = [];
+    function drawGraph() {
+        var c = document.getElementById('rssiChart');
+        var ctx = c.getContext('2d');
+        ctx.clearRect(0, 0, c.width, c.height);
+        if (rssiData.length < 2)
+            return;
+        ctx.beginPath();
+        for (var i = 0; i < rssiData.length; i++) {
+            var x = i * c.width / (rssiData.length - 1);
+            var y = c.height - (rssiData[i] + 100) * c.height / 100;
+            if (i === 0)
+                ctx.moveTo(x, y);
+            else
+                ctx.lineTo(x, y);
+        }
+        ctx.strokeStyle = '#00f';
+        ctx.stroke();
+    }
+
+    function update_stats() {
+        var url = '<%=url('admin/services/wfb-ng/stats')%>';
+        XHR.get(url, null, function(x, data) {
+            try {
+                var obj = JSON.parse(data);
+                if (obj.rx_ant_stats && obj.rx_ant_stats[0]) {
+                    rssiData.push(parseInt(obj.rx_ant_stats[0].rssi_avg, 10));
+                    if (rssiData.length > 50)
+                        rssiData.shift();
+                    drawGraph();
+                }
+            } catch (e) {
+                /* ignore parsing errors */
+            }
+        });
+    }
+    update_stats();
+    window.setInterval(update_stats, 2000);
+</script>
+<%+footer%>


### PR DESCRIPTION
## Summary
- add LuCI app for configuring and monitoring wfb-ng
- document new package in OpenWrt README
- parse config file to prefill form fields
- live RSSI graph on status page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'twisted')*

------
https://chatgpt.com/codex/tasks/task_e_683fb99a938c832996a23855ebab0722